### PR TITLE
ArrowUp to expand bio

### DIFF
--- a/packages/extension/svelte-stuff/components/Swiper.svelte
+++ b/packages/extension/svelte-stuff/components/Swiper.svelte
@@ -148,6 +148,7 @@
     <div style="margin-bottom: 4px;">Keyboard shortcuts:</div>
     <div>ArrowLeft or h: Nope</div>
     <div>ArrowRight or l: Like</div>
+    <div>ArrowUp: Expand bio</div>
     <div>Spacebar: Next photo</div>
   </div>
   <div class="center">

--- a/packages/extension/svelte-stuff/ui/CodeCard.svelte
+++ b/packages/extension/svelte-stuff/ui/CodeCard.svelte
@@ -125,6 +125,9 @@
     if (e.key === ' ') {
       onRightImage();
       e.preventDefault();
+    } else if (e.key === "ArrowUp") {
+        expanded = !expanded;
+        e.preventDefault();
     }
   }} />
 


### PR DESCRIPTION
The current shortcuts let you do pretty much everything without having to touch the mouse, except expand the bio.

In my experience, having to switch to the mouse often can be annoying.
Hence, this.