### PR TITLE
Age range for friendship

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -365,10 +365,6 @@ const main = async () => {
       })
     ),
     async (req: any, res, next) => {
-      if (req.body.goal === "friendship") {
-        req.body.ageRangeMin = 18;
-        req.body.ageRangeMax = 33;
-      }
       if (!req.body.location) {
         req.body.location = "";
       }
@@ -488,10 +484,16 @@ const main = async () => {
         myAge,
         ...user.gendersToShow,
       ];
-      const friendWhere = `and goal = 'friendship' and date_part('year', age(birthday)) ${
+      const friendWhere = `
+        and goal = 'friendship'
+        and date_part('year', age(birthday)) ${
         myAge >= 18 ? ">=" : "<"
-      } 18`;
-      const friendParams = [req.userId, req.userId, req.userId];
+      } 18
+      and $${paramNum} <= date_part('year', age(birthday))
+      and $${paramNum + 1} >= date_part('year', age(birthday))
+      and "ageRangeMin" <= $${paramNum + 2}
+      and "ageRangeMax" >= $${paramNum + 3}`;
+      const friendParams = [req.userId, req.userId, req.userId, user.ageRangeMin, user.ageRangeMax, myAge, myAge];
 
       const profiles = await getConnection().query(
         `

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -30,8 +30,8 @@ export const UpdateUser = object({
   location: length(string(), -1, 201),
   global: boolean(),
   birthday: pattern(string(), /^\d\d\d\d-\d\d-\d\d$/),
-  ageRangeMax: IntegerRange(17, 151),
-  ageRangeMin: IntegerRange(17, 151),
+  ageRangeMax: IntegerRange(-1, 151),
+  ageRangeMin: IntegerRange(-1, 151),
   flair: length(string(), -1, 100),
   pushToken: nullable(optional(string())),
 });

--- a/packages/extension/svelte-stuff/screens/EditProfile.svelte
+++ b/packages/extension/svelte-stuff/screens/EditProfile.svelte
@@ -142,6 +142,32 @@
       bind:value={data.goal}
       options={[{ label: age && age < 18 ? 'love 18+' : 'love', value: 'love' }, { label: 'friendship', value: 'friendship' }]} />
   </div>
+  <div>
+    <div class="label">Age Range:</div>
+    <div class="row">
+      <div class="row">
+        <InputField
+          required
+          type="number"
+          min={age && age < 18 ? 0 : 18}
+          max={age && age < 18 ? 18 : 151}
+          name="minAgeRange"
+          placeholder="18"
+          bind:value={data.ageRangeMin} />
+      </div>
+      <span />
+      <div class="row">
+        <InputField
+          required
+          placeholder="18"
+          type="number"
+          min={age && age < 18 ? 0 : 18}
+          max={age && age < 18 ? 18 : 151}
+          name="maxAgeRange"
+          bind:value={data.ageRangeMax} />
+      </div>
+    </div>
+  </div>
   {#if data.goal === 'love'}
     <div>
       <div class="label">Gender:</div>
@@ -157,32 +183,6 @@
           options={[{ label: 'males', value: 'male' }, { label: 'females', value: 'female' }, { label: 'non-binary', value: 'non-binary' }]} />
       </div>
     {/if}
-    <div>
-      <div class="label">Age Range:</div>
-      <div class="row">
-        <div class="row">
-          <InputField
-            required
-            type="number"
-            min={18}
-            max={150}
-            name="minAgeRange"
-            placeholder="18"
-            bind:value={data.ageRangeMin} />
-        </div>
-        <span />
-        <div class="row">
-          <InputField
-            required
-            placeholder="24"
-            type="number"
-            min={18}
-            max={150}
-            name="maxAgeRange"
-            bind:value={data.ageRangeMax} />
-        </div>
-      </div>
-    </div>
   {/if}
   <div style="padding-top: 20px;">
     <LoadingButton

--- a/packages/extension/svelte-stuff/screens/EditProfile.svelte
+++ b/packages/extension/svelte-stuff/screens/EditProfile.svelte
@@ -152,14 +152,14 @@
           min={age && age < 18 ? 0 : 18}
           max={age && age < 18 ? 18 : 150}
           name="minAgeRange"
-          placeholder="18"
+          placeholder={age && age < 18 ? "14" : "18"}
           bind:value={data.ageRangeMin} />
       </div>
       <span />
       <div class="row">
         <InputField
           required
-          placeholder="18"
+          placeholder={age && age < 18 ? "18" : "24"}
           type="number"
           min={age && age < 18 ? 0 : 18}
           max={age && age < 18 ? 18 : 150}

--- a/packages/extension/svelte-stuff/screens/EditProfile.svelte
+++ b/packages/extension/svelte-stuff/screens/EditProfile.svelte
@@ -150,7 +150,7 @@
           required
           type="number"
           min={age && age < 18 ? 0 : 18}
-          max={age && age < 18 ? 18 : 151}
+          max={age && age < 18 ? 18 : 150}
           name="minAgeRange"
           placeholder="18"
           bind:value={data.ageRangeMin} />
@@ -162,7 +162,7 @@
           placeholder="18"
           type="number"
           min={age && age < 18 ? 0 : 18}
-          max={age && age < 18 ? 18 : 151}
+          max={age && age < 18 ? 18 : 150}
           name="maxAgeRange"
           bind:value={data.ageRangeMax} />
       </div>


### PR DESCRIPTION
Title self explanatory.
_Why?_: Maybe someone is 17 and they don't want to match with 8 year old's.

Age range now shows for everybody, works according to this table:

| Category | Min | Min  | Max | Max |
|----------|-----|-----|-----|-----|
| Type     | Min | Max | Min | Max |
| Age > 18 | 18  | 150 | 18  | 150 |
| Age < 18 | 0   | 18  | 0   | 18  |

I recommend testing this yourself. However, even if somebody somehow bypasses the age range, the API will stop them anyway.
Users on the app won't be affected since the default age range is 0 - 100 anyway, and the over 18 check for friendships is still there

![example](https://user-images.githubusercontent.com/33849459/102936863-e1e0e300-44a0-11eb-8dbc-d7a0d63ea803.gif)
